### PR TITLE
Fix runtime issues

### DIFF
--- a/SkillBallBingo.Application/Models/Cell.cs
+++ b/SkillBallBingo.Application/Models/Cell.cs
@@ -1,4 +1,4 @@
-﻿namespace SkillBallBingo.Console;
+﻿namespace SkillBallBingo.Application.Models;
 
 public class Cell
 {

--- a/SkillBallBingo.Application/Models/Game.cs
+++ b/SkillBallBingo.Application/Models/Game.cs
@@ -1,4 +1,3 @@
-﻿using SkillBallBingo.Console;
 
 namespace SkillBallBingo.Application.Models;
 
@@ -114,6 +113,11 @@ public class Game
     
     private int GetRandomNumber()
     {
+        if (AvailableNumbers.Count == 0)
+        {
+            throw new InvalidOperationException("No numbers left to draw.");
+        }
+
         var randomIndex = Random.Next(0, AvailableNumbers.Count);
         var selectedNumber = AvailableNumbers[randomIndex];
         AvailableNumbers.Remove(selectedNumber);
@@ -124,7 +128,7 @@ public class Game
     private bool NumberExistsInTicket(int number)
     {
         return Ticket.SelectMany(row => row)
-            .Where(cell => cell != null)
-            .Any(cell => cell.Number == number);
+            .Where(cell => cell is not null)
+            .Any(cell => cell!.Number == number);
     }
 }

--- a/SkillBallBingo.Web/Components/Pages/Bingo.razor
+++ b/SkillBallBingo.Web/Components/Pages/Bingo.razor
@@ -1,4 +1,5 @@
 ﻿@page "/"
+@using Microsoft.JSInterop
 @using SkillBallBingo.Application.Models
 @rendermode InteractiveServer
 @inject IJSRuntime JS
@@ -45,8 +46,11 @@
     <button class="btn btn-primary" @onclick="StartGame">New Game</button>
 }
 
+@implements IAsyncDisposable
+
 @code {
     private Game? _game;
+    private DotNetObjectReference<Bingo>? _objectRef;
 
     private void StartGame()
     {
@@ -57,8 +61,17 @@
     {
         if (firstRender)
         {
-            await JS.InvokeVoidAsync("keyboardInterop.initialize",
-                DotNetObjectReference.Create(this));
+            _objectRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("keyboardInterop.initialize", _objectRef);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_objectRef is not null)
+        {
+            await JS.InvokeVoidAsync("keyboardInterop.dispose");
+            _objectRef.Dispose();
         }
     }
 

--- a/SkillBallBingo.Web/wwwroot/scripts.js
+++ b/SkillBallBingo.Web/wwwroot/scripts.js
@@ -1,7 +1,18 @@
-﻿window.keyboardInterop = {
+window.keyboardInterop = {
     initialize: function (dotNetRef) {
-        window.addEventListener('keydown', function (e) {
+        const handler = function (e) {
             dotNetRef.invokeMethodAsync('OnKeyDown', e.key);
-        });
+        };
+        window.addEventListener('keydown', handler);
+        this.handler = handler;
+        this.ref = dotNetRef;
+    },
+    dispose: function () {
+        if (this.handler) {
+            window.removeEventListener('keydown', this.handler);
+            this.ref.dispose();
+            this.handler = null;
+            this.ref = null;
+        }
     }
 };


### PR DESCRIPTION
## Summary
- fix Cell namespace so library references work
- guard against drawing numbers after they're exhausted
- avoid null warnings in `NumberExistsInTicket`
- dispose JS interop references in Bingo page
- manage JS keyboard listener lifecycle

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_687e0c2a9064832aa81c0a309adf99c3